### PR TITLE
Feature/task 1 - add EducationChampionat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+.vscode
+.idea

--- a/internal/app/commands/education/championat/callback_list.go
+++ b/internal/app/commands/education/championat/callback_list.go
@@ -10,10 +10,11 @@ import (
 )
 
 type CallbackListData struct {
-	Offset int `json:"offset"`
+	Offset uint64 `json:"Offset"`
 }
 
 func (c *ChampionatCommander) CallbackList(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+
 	parsedData := CallbackListData{}
 	err := json.Unmarshal([]byte(callbackPath.CallbackData), &parsedData)
 	if err != nil {
@@ -22,10 +23,43 @@ func (c *ChampionatCommander) CallbackList(callback *tgbotapi.CallbackQuery, cal
 			"input string %v - %v", callbackPath.CallbackData, err)
 		return
 	}
-	msg := tgbotapi.NewMessage(
-		callback.Message.Chat.ID,
-		fmt.Sprintf("Parsed: %+v\n", parsedData),
+
+	const defaultLimit = 3
+	outputMsgText := fmt.Sprintf("List of the championat (from %v to %v)\n\n", parsedData.Offset, parsedData.Offset+defaultLimit-1)
+	products := c.championatService.List(parsedData.Offset, defaultLimit)
+	for _, p := range products {
+		outputMsgText += p.Title
+		outputMsgText += "\n"
+	}
+
+	if len(products) == 0 {
+		msg := tgbotapi.NewMessage(callback.Message.Chat.ID, "No more championat!")
+		_, err = c.bot.Send(msg)
+		if err != nil {
+			log.Printf("ChampionatCommander.CallbackList: error sending reply message to chat - %v", err)
+		}
+		return
+	}
+
+	msg := tgbotapi.NewMessage(callback.Message.Chat.ID, outputMsgText)
+
+	serializedData, _ := json.Marshal(CallbackListData{
+		Offset: parsedData.Offset + defaultLimit,
+	})
+
+	newCallbackPath := path.CallbackPath{
+		Domain:       "education",
+		Subdomain:    "championat",
+		CallbackName: "list",
+		CallbackData: string(serializedData),
+	}
+
+	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("Next page", newCallbackPath.String()),
+		),
 	)
+
 	_, err = c.bot.Send(msg)
 	if err != nil {
 		log.Printf("ChampionatCommander.CallbackList: error sending reply message to chat - %v", err)

--- a/internal/app/commands/education/championat/callback_list.go
+++ b/internal/app/commands/education/championat/callback_list.go
@@ -26,13 +26,13 @@ func (c *ChampionatCommander) CallbackList(callback *tgbotapi.CallbackQuery, cal
 
 	const defaultLimit = 3
 	outputMsgText := fmt.Sprintf("List of the championat (from %v to %v)\n\n", parsedData.Offset, parsedData.Offset+defaultLimit-1)
-	products := c.championatService.List(parsedData.Offset, defaultLimit)
-	for _, p := range products {
-		outputMsgText += p.Title
+	championats := c.championatService.List(parsedData.Offset, defaultLimit)
+	for _, p := range championats {
+		outputMsgText += p.String()
 		outputMsgText += "\n"
 	}
 
-	if len(products) == 0 {
+	if len(championats) == 0 {
 		msg := tgbotapi.NewMessage(callback.Message.Chat.ID, "No more championat!")
 		_, err = c.bot.Send(msg)
 		if err != nil {

--- a/internal/app/commands/education/championat/callback_list.go
+++ b/internal/app/commands/education/championat/callback_list.go
@@ -1,0 +1,33 @@
+package championat
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+type CallbackListData struct {
+	Offset int `json:"offset"`
+}
+
+func (c *ChampionatCommander) CallbackList(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	parsedData := CallbackListData{}
+	err := json.Unmarshal([]byte(callbackPath.CallbackData), &parsedData)
+	if err != nil {
+		log.Printf("ChampionatCommander.CallbackList: "+
+			"error reading json data for type CallbackListData from "+
+			"input string %v - %v", callbackPath.CallbackData, err)
+		return
+	}
+	msg := tgbotapi.NewMessage(
+		callback.Message.Chat.ID,
+		fmt.Sprintf("Parsed: %+v\n", parsedData),
+	)
+	_, err = c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.CallbackList: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_default.go
+++ b/internal/app/commands/education/championat/command_default.go
@@ -1,0 +1,20 @@
+package championat
+
+import (
+	"log"
+	"strings"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *ChampionatCommander) Default(inputMessage *tgbotapi.Message) {
+	log.Printf("[%s] %s", inputMessage.From.UserName, inputMessage.Text)
+
+	msgParts := strings.SplitN(inputMessage.Text, "__", 3)
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, "Unknown command: "+msgParts[0])
+
+	_, err := c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.Help: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_delete.go
+++ b/internal/app/commands/education/championat/command_delete.go
@@ -1,0 +1,33 @@
+package championat
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"log"
+	"strconv"
+)
+
+func (c *ChampionatCommander) Delete(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	idx, err := strconv.Atoi(args)
+	if err != nil {
+		log.Println("wrong args", args)
+		return
+	}
+
+	err = c.championatService.Delete(idx)
+	if err != nil {
+		log.Printf("fail to delete championat with id %v: %v", idx, err)
+		return
+	}
+
+	msg := tgbotapi.NewMessage(
+		inputMessage.Chat.ID,
+		"Championat with id "+strconv.Itoa(idx)+" was deleted!",
+	)
+
+	_, err = c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.Get: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_delete.go
+++ b/internal/app/commands/education/championat/command_delete.go
@@ -11,7 +11,19 @@ func (c *ChampionatCommander) Delete(inputMessage *tgbotapi.Message) {
 
 	idx, err := strconv.Atoi(args)
 	if err != nil {
-		log.Println("wrong args", args)
+		msg := tgbotapi.NewMessage(
+			inputMessage.Chat.ID,
+			"Wrong ID: it should be a positive integer number",
+		)
+		_, err = c.bot.Send(msg)
+		return
+	}
+	if idx < 0 {
+		msg := tgbotapi.NewMessage(
+			inputMessage.Chat.ID,
+			"Wrong ID: it should be a positive number",
+		)
+		_, err = c.bot.Send(msg)
 		return
 	}
 

--- a/internal/app/commands/education/championat/command_delete.go
+++ b/internal/app/commands/education/championat/command_delete.go
@@ -15,7 +15,7 @@ func (c *ChampionatCommander) Delete(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	err = c.championatService.Delete(idx)
+	err = c.championatService.Remove(uint64(idx))
 	if err != nil {
 		log.Printf("fail to delete championat with id %v: %v", idx, err)
 		return
@@ -28,6 +28,6 @@ func (c *ChampionatCommander) Delete(inputMessage *tgbotapi.Message) {
 
 	_, err = c.bot.Send(msg)
 	if err != nil {
-		log.Printf("ChampionatCommander.Get: error sending reply message to chat - %v", err)
+		log.Printf("ChampionatCommander.Describe: error sending reply message to chat - %v", err)
 	}
 }

--- a/internal/app/commands/education/championat/command_edit.go
+++ b/internal/app/commands/education/championat/command_edit.go
@@ -1,0 +1,34 @@
+package championat
+
+import (
+	"encoding/json"
+	"fmt"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"log"
+	"strings"
+)
+
+func (c *ChampionatCommander) Edit(inputMessage *tgbotapi.Message) {
+	msgParts := strings.SplitN(inputMessage.Text, " ", 2)
+	editData := ChampionatEditData{}
+
+	err := json.Unmarshal([]byte(msgParts[1]), &editData)
+	if err != nil {
+		log.Printf("fail to unmarshal championat from text: %v. Error: %v", msgParts[1], err)
+		return
+	}
+
+	err = c.championatService.Edit(editData.ID, editData.Title)
+	if err != nil {
+		log.Printf("fail to edit championat with id %v: %v", editData.ID, err)
+		return
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID,
+		fmt.Sprintf("Championat with id %v was edited!", editData.ID),
+	)
+	_, err = c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.Help: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_edit.go
+++ b/internal/app/commands/education/championat/command_edit.go
@@ -18,7 +18,7 @@ func (c *ChampionatCommander) Edit(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	err = c.championatService.Edit(editData.ID, editData.Title)
+	err = c.championatService.Update(editData.ID, editData.Title)
 	if err != nil {
 		log.Printf("fail to edit championat with id %v: %v", editData.ID, err)
 		return

--- a/internal/app/commands/education/championat/command_edit.go
+++ b/internal/app/commands/education/championat/command_edit.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/service/education/championat"
 	"log"
 	"strings"
 )
@@ -18,7 +19,8 @@ func (c *ChampionatCommander) Edit(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	err = c.championatService.Update(editData.ID, editData.Title)
+	var newChampionat = championat.Championat{Title: editData.Title}
+	err = c.championatService.Update(editData.ID, newChampionat)
 	if err != nil {
 		log.Printf("fail to edit championat with id %v: %v", editData.ID, err)
 		return

--- a/internal/app/commands/education/championat/command_get.go
+++ b/internal/app/commands/education/championat/command_get.go
@@ -28,15 +28,15 @@ func (c *ChampionatCommander) Get(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	product, err := c.championatService.Describe(uint64(idx))
+	championat, err := c.championatService.Describe(uint64(idx))
 	if err != nil {
-		log.Printf("fail to get product with idx %d: %v", idx, err)
+		log.Printf("fail to get championat with idx %d: %v", idx, err)
 		return
 	}
 
 	msg := tgbotapi.NewMessage(
 		inputMessage.Chat.ID,
-		product.Title,
+		championat.String(),
 	)
 
 	_, err = c.bot.Send(msg)

--- a/internal/app/commands/education/championat/command_get.go
+++ b/internal/app/commands/education/championat/command_get.go
@@ -12,7 +12,19 @@ func (c *ChampionatCommander) Get(inputMessage *tgbotapi.Message) {
 
 	idx, err := strconv.Atoi(args)
 	if err != nil {
-		log.Println("wrong args", args)
+		msg := tgbotapi.NewMessage(
+			inputMessage.Chat.ID,
+			"Wrong ID: it should be a positive integer number",
+		)
+		_, err = c.bot.Send(msg)
+		return
+	}
+	if idx < 0 {
+		msg := tgbotapi.NewMessage(
+			inputMessage.Chat.ID,
+			"Wrong ID: it should be a positive number",
+		)
+		_, err = c.bot.Send(msg)
 		return
 	}
 

--- a/internal/app/commands/education/championat/command_get.go
+++ b/internal/app/commands/education/championat/command_get.go
@@ -16,7 +16,7 @@ func (c *ChampionatCommander) Get(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	product, err := c.championatService.Get(idx)
+	product, err := c.championatService.Describe(uint64(idx))
 	if err != nil {
 		log.Printf("fail to get product with idx %d: %v", idx, err)
 		return
@@ -29,6 +29,6 @@ func (c *ChampionatCommander) Get(inputMessage *tgbotapi.Message) {
 
 	_, err = c.bot.Send(msg)
 	if err != nil {
-		log.Printf("ChampionatCommander.Get: error sending reply message to chat - %v", err)
+		log.Printf("ChampionatCommander.Describe: error sending reply message to chat - %v", err)
 	}
 }

--- a/internal/app/commands/education/championat/command_get.go
+++ b/internal/app/commands/education/championat/command_get.go
@@ -1,0 +1,34 @@
+package championat
+
+import (
+	"log"
+	"strconv"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *ChampionatCommander) Get(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	idx, err := strconv.Atoi(args)
+	if err != nil {
+		log.Println("wrong args", args)
+		return
+	}
+
+	product, err := c.championatService.Get(idx)
+	if err != nil {
+		log.Printf("fail to get product with idx %d: %v", idx, err)
+		return
+	}
+
+	msg := tgbotapi.NewMessage(
+		inputMessage.Chat.ID,
+		product.Title,
+	)
+
+	_, err = c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.Get: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_help.go
+++ b/internal/app/commands/education/championat/command_help.go
@@ -1,0 +1,22 @@
+package championat
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"log"
+)
+
+func (c *ChampionatCommander) Help(inputMessage *tgbotapi.Message) {
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID,
+		"/help__education__championat — print list of commands\n"+
+			"/get__education__championat - get an entity\n"+
+			"/list__education__championat - get a list of entity\n"+
+			"/delete__education__championat - delete an existing entity\n"+
+			"/new__education__championat - create an entity\n"+
+			"/edit__education__championat - edit an entity",
+	)
+
+	_, err := c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.Help: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_help.go
+++ b/internal/app/commands/education/championat/command_help.go
@@ -7,12 +7,13 @@ import (
 
 func (c *ChampionatCommander) Help(inputMessage *tgbotapi.Message) {
 	msg := tgbotapi.NewMessage(inputMessage.Chat.ID,
-		"/help__education__championat — print list of commands\n"+
-			"/get__education__championat - get an entity\n"+
+		"/help__education__championat - print list of commands\n"+
+			"/get__education__championat id - get an entity\n"+
 			"/list__education__championat - get a list of entity\n"+
-			"/delete__education__championat - delete an existing entity\n"+
-			"/new__education__championat - create an entity\n"+
-			"/edit__education__championat - edit an entity",
+			"/delete__education__championat id - delete an existing entity\n"+
+			`/new__education__championat { "title": "string" } - create an entity`+
+			"\n"+
+			`/edit__education__championat { "id": int, "title": "string"} - edit an entity`,
 	)
 
 	_, err := c.bot.Send(msg)

--- a/internal/app/commands/education/championat/command_list.go
+++ b/internal/app/commands/education/championat/command_list.go
@@ -1,0 +1,43 @@
+package championat
+
+import (
+	"encoding/json"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+func (c *ChampionatCommander) List(inputMessage *tgbotapi.Message) {
+	outputMsgText := "Here all the championat: \n\n"
+
+	products := c.championatService.List()
+	for _, p := range products {
+		outputMsgText += p.Title
+		outputMsgText += "\n"
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, outputMsgText)
+
+	serializedData, _ := json.Marshal(CallbackListData{
+		Offset: 21,
+	})
+
+	callbackPath := path.CallbackPath{
+		Domain:       "education",
+		Subdomain:    "championat",
+		CallbackName: "list",
+		CallbackData: string(serializedData),
+	}
+
+	msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("Next page", callbackPath.String()),
+		),
+	)
+
+	_, err := c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.List: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/command_list.go
+++ b/internal/app/commands/education/championat/command_list.go
@@ -2,6 +2,7 @@ package championat
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
@@ -9,9 +10,8 @@ import (
 )
 
 func (c *ChampionatCommander) List(inputMessage *tgbotapi.Message) {
-	outputMsgText := "Here all the championat: \n\n"
-
-	const defaultLimit = 2
+	const defaultLimit = 3
+	outputMsgText := fmt.Sprintf("List of the championat (from %v to %v)\n\n", 0, defaultLimit-1)
 	products := c.championatService.List(0, defaultLimit)
 	for _, p := range products {
 		outputMsgText += p.Title
@@ -21,7 +21,7 @@ func (c *ChampionatCommander) List(inputMessage *tgbotapi.Message) {
 	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, outputMsgText)
 
 	serializedData, _ := json.Marshal(CallbackListData{
-		Offset: defaultLimit + 1,
+		Offset: defaultLimit,
 	})
 
 	callbackPath := path.CallbackPath{

--- a/internal/app/commands/education/championat/command_list.go
+++ b/internal/app/commands/education/championat/command_list.go
@@ -12,9 +12,9 @@ import (
 func (c *ChampionatCommander) List(inputMessage *tgbotapi.Message) {
 	const defaultLimit = 3
 	outputMsgText := fmt.Sprintf("List of the championat (from %v to %v)\n\n", 0, defaultLimit-1)
-	products := c.championatService.List(0, defaultLimit)
-	for _, p := range products {
-		outputMsgText += p.Title
+	championats := c.championatService.List(0, defaultLimit)
+	for _, p := range championats {
+		outputMsgText += p.String()
 		outputMsgText += "\n"
 	}
 

--- a/internal/app/commands/education/championat/command_list.go
+++ b/internal/app/commands/education/championat/command_list.go
@@ -11,7 +11,8 @@ import (
 func (c *ChampionatCommander) List(inputMessage *tgbotapi.Message) {
 	outputMsgText := "Here all the championat: \n\n"
 
-	products := c.championatService.List()
+	const defaultLimit = 2
+	products := c.championatService.List(0, defaultLimit)
 	for _, p := range products {
 		outputMsgText += p.Title
 		outputMsgText += "\n"
@@ -20,7 +21,7 @@ func (c *ChampionatCommander) List(inputMessage *tgbotapi.Message) {
 	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, outputMsgText)
 
 	serializedData, _ := json.Marshal(CallbackListData{
-		Offset: 21,
+		Offset: defaultLimit + 1,
 	})
 
 	callbackPath := path.CallbackPath{

--- a/internal/app/commands/education/championat/command_new.go
+++ b/internal/app/commands/education/championat/command_new.go
@@ -4,28 +4,30 @@ import (
 	"encoding/json"
 	"fmt"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/service/education/championat"
 	"log"
 	"strings"
 )
 
 func (c *ChampionatCommander) New(inputMessage *tgbotapi.Message) {
 	msgParts := strings.SplitN(inputMessage.Text, " ", 2)
-	editData := ChampionatCreateData{}
+	createData := ChampionatCreateData{}
 
-	err := json.Unmarshal([]byte(msgParts[1]), &editData)
+	err := json.Unmarshal([]byte(msgParts[1]), &createData)
 	if err != nil {
 		log.Printf("fail to unmarshal championat from text: %v. Error: %v", msgParts[1], err)
 		return
 	}
 
-	err = c.championatService.Create(editData.Title)
+	var editedChampionat = championat.Championat{Title: createData.Title}
+	err = c.championatService.Create(editedChampionat)
 	if err != nil {
-		log.Printf("fail to create championat with title %v: %v", editData.Title, err)
+		log.Printf("fail to create championat with title %v: %v", createData.Title, err)
 		return
 	}
 
 	msg := tgbotapi.NewMessage(inputMessage.Chat.ID,
-		fmt.Sprintf("Championat with title %v was created!", editData.Title),
+		fmt.Sprintf("Championat with title %v was created!", createData.Title),
 	)
 	_, err = c.bot.Send(msg)
 	if err != nil {

--- a/internal/app/commands/education/championat/command_new.go
+++ b/internal/app/commands/education/championat/command_new.go
@@ -18,7 +18,7 @@ func (c *ChampionatCommander) New(inputMessage *tgbotapi.Message) {
 		return
 	}
 
-	err = c.championatService.New(editData.Title)
+	err = c.championatService.Create(editData.Title)
 	if err != nil {
 		log.Printf("fail to create championat with title %v: %v", editData.Title, err)
 		return

--- a/internal/app/commands/education/championat/command_new.go
+++ b/internal/app/commands/education/championat/command_new.go
@@ -1,0 +1,34 @@
+package championat
+
+import (
+	"encoding/json"
+	"fmt"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"log"
+	"strings"
+)
+
+func (c *ChampionatCommander) New(inputMessage *tgbotapi.Message) {
+	msgParts := strings.SplitN(inputMessage.Text, " ", 2)
+	editData := ChampionatCreateData{}
+
+	err := json.Unmarshal([]byte(msgParts[1]), &editData)
+	if err != nil {
+		log.Printf("fail to unmarshal championat from text: %v. Error: %v", msgParts[1], err)
+		return
+	}
+
+	err = c.championatService.New(editData.Title)
+	if err != nil {
+		log.Printf("fail to create championat with title %v: %v", editData.Title, err)
+		return
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID,
+		fmt.Sprintf("Championat with title %v was created!", editData.Title),
+	)
+	_, err = c.bot.Send(msg)
+	if err != nil {
+		log.Printf("ChampionatCommander.Help: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/education/championat/commander.go
+++ b/internal/app/commands/education/championat/commander.go
@@ -10,13 +10,13 @@ import (
 
 type ChampionatCommander struct {
 	bot               *tgbotapi.BotAPI
-	championatService *championat.Service
+	championatService *championat.DummyChampionatService
 }
 
 func NewChampionatCommander(
 	bot *tgbotapi.BotAPI,
 ) *ChampionatCommander {
-	championatService := championat.NewService()
+	championatService := championat.NewDummyChampionatService()
 
 	return &ChampionatCommander{
 		bot:               bot,

--- a/internal/app/commands/education/championat/commander.go
+++ b/internal/app/commands/education/championat/commander.go
@@ -42,7 +42,7 @@ func (c *ChampionatCommander) HandleCommand(msg *tgbotapi.Message, commandPath p
 	case "get":
 		c.Get(msg)
 	case "delete":
-		c.Get(msg)
+		c.Delete(msg)
 	case "new":
 		c.New(msg)
 	case "edit":

--- a/internal/app/commands/education/championat/commander.go
+++ b/internal/app/commands/education/championat/commander.go
@@ -1,0 +1,53 @@
+package championat
+
+import (
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+	"github.com/ozonmp/omp-bot/internal/service/education/championat"
+)
+
+type ChampionatCommander struct {
+	bot               *tgbotapi.BotAPI
+	championatService *championat.Service
+}
+
+func NewChampionatCommander(
+	bot *tgbotapi.BotAPI,
+) *ChampionatCommander {
+	championatService := championat.NewService()
+
+	return &ChampionatCommander{
+		bot:               bot,
+		championatService: championatService,
+	}
+}
+
+func (c *ChampionatCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.CallbackName {
+	case "list":
+		c.CallbackList(callback, callbackPath)
+	default:
+		log.Printf("ChampionatCommander.HandleCallback: unknown callback name: %s", callbackPath.CallbackName)
+	}
+}
+
+func (c *ChampionatCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.CommandName {
+	case "help":
+		c.Help(msg)
+	case "list":
+		c.List(msg)
+	case "get":
+		c.Get(msg)
+	case "delete":
+		c.Get(msg)
+	case "new":
+		c.New(msg)
+	case "edit":
+		c.Edit(msg)
+	default:
+		c.Default(msg)
+	}
+}

--- a/internal/app/commands/education/championat/models.go
+++ b/internal/app/commands/education/championat/models.go
@@ -1,0 +1,10 @@
+package championat
+
+type ChampionatEditData struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+}
+
+type ChampionatCreateData struct {
+	Title string `json:"title"`
+}

--- a/internal/app/commands/education/championat/models.go
+++ b/internal/app/commands/education/championat/models.go
@@ -1,7 +1,7 @@
 package championat
 
 type ChampionatEditData struct {
-	ID    int    `json:"id"`
+	ID    uint64 `json:"id"`
 	Title string `json:"title"`
 }
 

--- a/internal/app/commands/education/commander.go
+++ b/internal/app/commands/education/commander.go
@@ -1,0 +1,47 @@
+package education
+
+import (
+	"github.com/ozonmp/omp-bot/internal/app/commands/education/championat"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+type Commander interface {
+	HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath)
+	HandleCommand(message *tgbotapi.Message, commandPath path.CommandPath)
+}
+
+type EducationCommander struct {
+	bot                 *tgbotapi.BotAPI
+	championatCommander Commander
+}
+
+func NewEducationCommander(
+	bot *tgbotapi.BotAPI,
+) *EducationCommander {
+	return &EducationCommander{
+		bot: bot,
+		// championatCommander
+		championatCommander: championat.NewChampionatCommander(bot),
+	}
+}
+
+func (c *EducationCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.Subdomain {
+	case "championat":
+		c.championatCommander.HandleCallback(callback, callbackPath)
+	default:
+		log.Printf("EducationCommander.HandleCallback: unknown subdomain - %s", callbackPath.Subdomain)
+	}
+}
+
+func (c *EducationCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.Subdomain {
+	case "championat":
+		c.championatCommander.HandleCommand(msg, commandPath)
+	default:
+		log.Printf("EducationCommander.HandleCommand: unknown subdomain - %s", commandPath.Subdomain)
+	}
+}

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -6,6 +6,7 @@ import (
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ozonmp/omp-bot/internal/app/commands/demo"
+	"github.com/ozonmp/omp-bot/internal/app/commands/education"
 	"github.com/ozonmp/omp-bot/internal/app/path"
 )
 
@@ -45,6 +46,7 @@ type Router struct {
 	// logistic
 	// product
 	// education
+	educationCommander Commander
 }
 
 func NewRouter(
@@ -80,6 +82,7 @@ func NewRouter(
 		// logistic
 		// product
 		// education
+		educationCommander: education.NewEducationCommander(bot),
 	}
 }
 
@@ -157,7 +160,7 @@ func (c *Router) handleCallback(callback *tgbotapi.CallbackQuery) {
 	case "product":
 		break
 	case "education":
-		break
+		c.educationCommander.HandleCallback(callback, callbackPath)
 	default:
 		log.Printf("Router.handleCallback: unknown domain - %s", callbackPath.Domain)
 	}
@@ -228,7 +231,7 @@ func (c *Router) handleMessage(msg *tgbotapi.Message) {
 	case "product":
 		break
 	case "education":
-		break
+		c.educationCommander.HandleCommand(msg, commandPath)
 	default:
 		log.Printf("Router.handleCallback: unknown domain - %s", commandPath.Domain)
 	}

--- a/internal/service/education/championat/models.go
+++ b/internal/service/education/championat/models.go
@@ -1,6 +1,6 @@
 package championat
 
-var allEntities = []Championat{
+var allChampionats = []Championat{
 	{Title: "ZeroChampionat"},
 	{Title: "FirstChampionat"},
 	{Title: "SecondChampionat"},
@@ -14,17 +14,17 @@ type Championat struct {
 }
 
 func newEntity(Title string) {
-	allEntities = append(allEntities, Championat{
+	allChampionats = append(allChampionats, Championat{
 		Title: Title,
 	})
 }
 
-func deleteEntity(i int) {
-	allEntities = append(allEntities[:i], allEntities[i+1:]...)
+func deleteEntity(i uint64) {
+	allChampionats = append(allChampionats[:i], allChampionats[i+1:]...)
 }
 
-func editEntity(i int, title string) {
-	allEntities[i] = Championat{
+func editEntity(i uint64, title string) {
+	allChampionats[i] = Championat{
 		Title: title,
 	}
 }

--- a/internal/service/education/championat/models.go
+++ b/internal/service/education/championat/models.go
@@ -1,0 +1,30 @@
+package championat
+
+var allEntities = []Championat{
+	{Title: "ZeroChampionat"},
+	{Title: "FirstChampionat"},
+	{Title: "SecondChampionat"},
+	{Title: "ThirdChampionat"},
+	{Title: "FourthChampionat"},
+	{Title: "FifthChampionat"},
+}
+
+type Championat struct {
+	Title string
+}
+
+func newEntity(Title string) {
+	allEntities = append(allEntities, Championat{
+		Title: Title,
+	})
+}
+
+func deleteEntity(i int) {
+	allEntities = append(allEntities[:i], allEntities[i+1:]...)
+}
+
+func editEntity(i int, title string) {
+	allEntities[i] = Championat{
+		Title: title,
+	}
+}

--- a/internal/service/education/championat/models.go
+++ b/internal/service/education/championat/models.go
@@ -12,19 +12,3 @@ var allChampionats = []Championat{
 type Championat struct {
 	Title string
 }
-
-func newEntity(Title string) {
-	allChampionats = append(allChampionats, Championat{
-		Title: Title,
-	})
-}
-
-func deleteEntity(i uint64) {
-	allChampionats = append(allChampionats[:i], allChampionats[i+1:]...)
-}
-
-func editEntity(i uint64, title string) {
-	allChampionats[i] = Championat{
-		Title: title,
-	}
-}

--- a/internal/service/education/championat/service.go
+++ b/internal/service/education/championat/service.go
@@ -10,8 +10,8 @@ func (s *DummyChampionatService) Describe(championatId uint64) (*Championat, err
 	return &allChampionats[championatId], nil
 }
 
-func (s *DummyChampionatService) List() []Championat {
-	return allChampionats
+func (s *DummyChampionatService) List(cursor uint64, limit uint64) []Championat {
+	return allChampionats[cursor : cursor+limit]
 }
 
 func (s *DummyChampionatService) Create(title string) error {

--- a/internal/service/education/championat/service.go
+++ b/internal/service/education/championat/service.go
@@ -21,17 +21,17 @@ func (s *DummyChampionatService) List(cursor uint64, limit uint64) []Championat 
 	return allChampionats[cursor : cursor+limit]
 }
 
-func (s *DummyChampionatService) Create(title string) error {
-	newEntity(title)
+func (s *DummyChampionatService) Create(championat Championat) error {
+	allChampionats = append(allChampionats, championat)
 	return nil
 }
 
-func (s *DummyChampionatService) Update(championatId uint64, title string) error {
-	editEntity(championatId, title)
+func (s *DummyChampionatService) Update(championatId uint64, championat Championat) error {
+	allChampionats[championatId] = championat
 	return nil
 }
 
 func (s *DummyChampionatService) Remove(championatId uint64) error {
-	deleteEntity(championatId)
+	allChampionats = append(allChampionats[:championatId], allChampionats[championatId+1:]...)
 	return nil
 }

--- a/internal/service/education/championat/service.go
+++ b/internal/service/education/championat/service.go
@@ -11,6 +11,13 @@ func (s *DummyChampionatService) Describe(championatId uint64) (*Championat, err
 }
 
 func (s *DummyChampionatService) List(cursor uint64, limit uint64) []Championat {
+	var championatsLen = uint64(len(allChampionats))
+	if cursor >= championatsLen {
+		cursor = championatsLen
+	}
+	if (cursor + limit) >= championatsLen {
+		limit = championatsLen - cursor
+	}
 	return allChampionats[cursor : cursor+limit]
 }
 

--- a/internal/service/education/championat/service.go
+++ b/internal/service/education/championat/service.go
@@ -1,30 +1,30 @@
 package championat
 
-type Service struct{}
+type DummyChampionatService struct{}
 
-func NewService() *Service {
-	return &Service{}
+func NewDummyChampionatService() *DummyChampionatService {
+	return &DummyChampionatService{}
 }
 
-func (s *Service) List() []Championat {
-	return allEntities
+func (s *DummyChampionatService) Describe(championatId uint64) (*Championat, error) {
+	return &allChampionats[championatId], nil
 }
 
-func (s *Service) Get(idx int) (*Championat, error) {
-	return &allEntities[idx], nil
+func (s *DummyChampionatService) List() []Championat {
+	return allChampionats
 }
 
-func (s *Service) New(title string) error {
+func (s *DummyChampionatService) Create(title string) error {
 	newEntity(title)
 	return nil
 }
 
-func (s *Service) Delete(id int) error {
-	deleteEntity(id)
+func (s *DummyChampionatService) Update(championatId uint64, title string) error {
+	editEntity(championatId, title)
 	return nil
 }
 
-func (s *Service) Edit(id int, title string) error {
-	editEntity(id, title)
+func (s *DummyChampionatService) Remove(championatId uint64) error {
+	deleteEntity(championatId)
 	return nil
 }

--- a/internal/service/education/championat/service.go
+++ b/internal/service/education/championat/service.go
@@ -35,3 +35,7 @@ func (s *DummyChampionatService) Remove(championatId uint64) error {
 	allChampionats = append(allChampionats[:championatId], allChampionats[championatId+1:]...)
 	return nil
 }
+
+func (ch *Championat) String() string {
+	return "Title: " + ch.Title
+}

--- a/internal/service/education/championat/service.go
+++ b/internal/service/education/championat/service.go
@@ -1,0 +1,30 @@
+package championat
+
+type Service struct{}
+
+func NewService() *Service {
+	return &Service{}
+}
+
+func (s *Service) List() []Championat {
+	return allEntities
+}
+
+func (s *Service) Get(idx int) (*Championat, error) {
+	return &allEntities[idx], nil
+}
+
+func (s *Service) New(title string) error {
+	newEntity(title)
+	return nil
+}
+
+func (s *Service) Delete(id int) error {
+	deleteEntity(id)
+	return nil
+}
+
+func (s *Service) Edit(id int, title string) error {
+	editEntity(id, title)
+	return nil
+}


### PR DESCRIPTION
### Domain: Education
### Subdomain: Championat

Реализованные команды:

**/help__education__championat** - _print list of commands_
**/get__education__championat id** - _get an entity_
**/list__education__championat** - _get a list of entity_
**/delete__education__championat id** - _delete an existing entity_
**/new__education__championat { "title": "string" }** - _create an entity_
**/edit__education__championat { "id": int, "title": "string"}** - _edit an entity_

По умолчанию в коде уже заложены шесть сущностей для быстрой проверки команды /list.

Для получения первой сущности следует использовать команду:
**/get__education__championat 0**

Если в качестве ID будет использовано число меньше нуля, то бот выдаст соответствующую ошибку.

<img width="614" alt="image" src="https://user-images.githubusercontent.com/28717027/138121955-3b81a588-d4ed-44c7-a42b-3b54a7bbe8f0.png">

Постраничное отображение списка реализовано с помощью кнопки Next Page. Бот показывает три сущности в одном сообщении, по нажатию на кнопку Next Page бот отправит следующие 3 сущности. По завершению списка бот выдаст информацию о том, что список закончился.

<img width="617" alt="image" src="https://user-images.githubusercontent.com/28717027/138118093-70504411-168b-4f18-84b9-4b8ad3e2a9cd.png">
